### PR TITLE
Creation of a PWGDQ documentation

### DIFF
--- a/docs/framework/pwgdq.md
+++ b/docs/framework/pwgdq.md
@@ -1,0 +1,17 @@
+---
+sort: 5
+title: PWGDQ
+---
+
+# Dimuon-Quarkonium (DQ) analysis framework
+
+## Contact
+
+Coordinators: Ionut Christian Arsene, Fiorella Fionda, Michael Andreas Winn
+
+Mattermost channel: [O2-DQ Analysis Framework Alpha](https://mattermost.web.cern.ch/alice/channels/o2-dq-analysis-framework-alpha)
+
+## Code
+
+* Tasks used by the heavy-flavour analysis framework are in the
+[`PWGDQ`](https://github.com/AliceO2Group/O2Physics/tree/master/PWGDQ) directory.


### PR DESCRIPTION
This is the first step for the creation of a PWGDQ documentation on the framework based on what was done for PWGHF.

