### PR TITLE
Add note about O2FV0C table to "missing tree" troubleshooting doc

### DIFF
--- a/docs/troubleshooting/treenotfound.md
+++ b/docs/troubleshooting/treenotfound.md
@@ -23,4 +23,6 @@ and the table should be found.
 
 If you run on Run 3 data or MC and the missing table is "O2tracks", please refer to the documentation on the [track propagation](../helperTasks/trackPropagation.md).
 
+If you are running on Run 3 data or MC and the missing table is "O2fv0c", please make sure that the process switches in the bc-selection, event-selection and multiplicity-table workflows are set to `processRun2: false, processRun3: true` in your config JSON; see e.g. the "Configurables" section in the [event selection](../helperTasks/eventselection.md#configurables) documentation.  
+
 If the misssing table is `O2tofsignal`, please refer to the documentation on the [TOF PID](../helperTasks/pid.md) requirements.

--- a/docs/troubleshooting/treenotfound.md
+++ b/docs/troubleshooting/treenotfound.md
@@ -23,6 +23,6 @@ and the table should be found.
 
 If you run on Run 3 data or MC and the missing table is "O2tracks", please refer to the documentation on the [track propagation](../helperTasks/trackPropagation.md).
 
-If you are running on Run 3 data or MC and the missing table is "O2fv0c", please make sure that the process switches in the bc-selection, event-selection and multiplicity-table workflows are set to `processRun2: false, processRun3: true` in your config JSON; see e.g. the "Configurables" section in the [event selection](../helperTasks/eventselection.md#configurables) documentation.  
+If you are running on Run 3 data or MC and the missing table is "O2fv0c", please make sure that the process switches in the bc-selection, event-selection and multiplicity-table workflows are set to `"processRun2": "false", "processRun3": "true"` in your config JSON; see e.g. the "Configurables" section in the [event selection](../helperTasks/eventselection.md#configurables) documentation.  
 
 If the misssing table is `O2tofsignal`, please refer to the documentation on the [TOF PID](../helperTasks/pid.md) requirements.


### PR DESCRIPTION
Adding a note about using the "processRun3" switch to address FAQ about the 'missing' FV0C table when processing run 3 data