### PR TITLE
Documentation: Fix typos, add examples, fix linking errors

### DIFF
--- a/docs/basics-tasks/BasicAnalysisTask.md
+++ b/docs/basics-tasks/BasicAnalysisTask.md
@@ -38,9 +38,13 @@ defineDataProcessing() {
 >
 > `AnalysisTask` will not actually provide any virtual method, as the `adaptAnalysis` helper relies on template argument matching to discover the properties of the task. It will come clear in the next paragraph how this allow is used to avoid the proliferation of data subscription methods.
 
-```todo
-Define minimum requirements for a complet task
-```
+###### Minimum requirements for a complete task
+
+- License agreement
+- Required header files
+- O2 basic name spaces
+- Struct comprising an init and a process function
+- Defined Workflow
 
 See also tutorial [Analysis Task](../tutorials/analysistask.md).
 
@@ -115,7 +119,7 @@ HistogramConfigSpec(HistType type,
                     uint8_t nSteps = 1)
 ```
 
-HistType specifies the type of the histogram. The supported hstograms types are listed in <a href="https://github.com/AliceO2Group/AliceO2/blob/dev/Framework/Core/include/Framework/HistogramSpec.h" target="_blank">HistogramSpec.h</a>. The vector of AxisSpec describe the axes of the histogram. nSteps is only used for histograms of type <a href="https://github.com/AliceO2Group/AliceO2/blob/dev/Framework/Core/include/Framework/StepTHn.h" target="_blank">StepTHn</a>.
+HistType specifies the type of the histogram. The supported histogram types are listed in <a href="https://github.com/AliceO2Group/AliceO2/blob/dev/Framework/Core/include/Framework/HistogramSpec.h" target="_blank">HistogramSpec.h</a>. The vector of AxisSpec describes the axes of the histogram. nSteps is only used for histograms of type <a href="https://github.com/AliceO2Group/AliceO2/blob/dev/Framework/Core/include/Framework/StepTHn.h" target="_blank">StepTHn</a>.
 
 Histogram axes are realized by AxisSpec which has two constructors.
 
@@ -131,7 +135,7 @@ AxisSpec(int nBins,
          std::optional<std::string> name = std::nullopt)
 ```
 
-They differ in the way the axis bins are defined. In the first version a vector of bin edges is provided, which allows for bins of different widths, whereas in the second case the edges of the equally wide bins are computed with the provided number of bins and the range of the axis, defined by binMin and binMax.
+They differ in the way the axis bins are defined. In the first version a vector of bin edges is provided, which allows bins of different widths, whereas in the second case the edges of the equally wide bins are computed with the provided number of bins and the range of the axis, defined by binMin and binMax.
 
 By-the-way, there is in fact a third version of the AxisSpec constructor, which is similar to the first version, but takes as first argument a ConfigurableAxis (= [Configurable](#configurables)&lt;std::vector&lt;double&gt;&gt;) instead of a std::vector&lt;double&gt;.
 
@@ -139,7 +143,7 @@ By-the-way, there is in fact a third version of the AxisSpec constructor, which 
 
 ## Adding histograms
 
-A HistogramRegistry can be created together with the histograms it contains. It can however also be created empty and the histograms can be added later with the add method of which there a three versions.
+A HistogramRegistry can be created together with the histograms it contains. It can however also be created empty and the histograms can be added later with the add method of which there are three versions.
 
 ```cpp
 void add(const HistogramSpec& histSpec);

--- a/docs/basics-tasks/BasicAnalysisTask.md
+++ b/docs/basics-tasks/BasicAnalysisTask.md
@@ -137,7 +137,7 @@ AxisSpec(int nBins,
 
 They differ in the way the axis bins are defined. In the first version a vector of bin edges is provided, which allows bins of different widths, whereas in the second case the edges of the equally wide bins are computed with the provided number of bins and the range of the axis, defined by binMin and binMax.
 
-By-the-way, there is in fact a third version of the AxisSpec constructor, which is similar to the first version, but takes as first argument a ConfigurableAxis (= Configurable&lt;std::vector&lt;double&gt;&gt;) instead of a std::vector&lt;double&gt;.
+By-the-way, there is in fact a third version of the AxisSpec constructor, which is similar to the first version, but takes as first argument a ConfigurableAxis (= [Configurable](../basics-usage/HelperTasks.md#configurables)&lt;std::vector&lt;double&gt;&gt;) instead of a std::vector&lt;double&gt;.
 
 <a name="addinghistograms"></a>
 

--- a/docs/basics-tasks/BasicAnalysisTask.md
+++ b/docs/basics-tasks/BasicAnalysisTask.md
@@ -137,7 +137,7 @@ AxisSpec(int nBins,
 
 They differ in the way the axis bins are defined. In the first version a vector of bin edges is provided, which allows bins of different widths, whereas in the second case the edges of the equally wide bins are computed with the provided number of bins and the range of the axis, defined by binMin and binMax.
 
-By-the-way, there is in fact a third version of the AxisSpec constructor, which is similar to the first version, but takes as first argument a ConfigurableAxis (= [Configurable](#configurables)&lt;std::vector&lt;double&gt;&gt;) instead of a std::vector&lt;double&gt;.
+By-the-way, there is in fact a third version of the AxisSpec constructor, which is similar to the first version, but takes as first argument a ConfigurableAxis (= Configurable&lt;std::vector&lt;double&gt;&gt;) instead of a std::vector&lt;double&gt;.
 
 <a name="addinghistograms"></a>
 

--- a/docs/basics-tasks/FilteringPartitioning.md
+++ b/docs/basics-tasks/FilteringPartitioning.md
@@ -129,4 +129,4 @@ struct MyTask : AnalysisTask {
 - Complete list of methods related to filters and partitions
 ```
 
-See also tutorials [Data Selection](../tutorials/dataSelection).
+See also tutorials [Data Selection](../tutorials/dataSelection.md).

--- a/docs/basics-tasks/FilteringPartitioning.md
+++ b/docs/basics-tasks/FilteringPartitioning.md
@@ -23,7 +23,9 @@ filters upfront you can not only simplify your code, but allow the framework to
 optimize the processing. To do so, we provide two helpers: `Filter` and
 `Partition`.
 
-*Note: Filters cannot be used on dynamic columns.*
+```note
+Filters cannot be used on dynamic columns.
+```
 
 ## Upfront filtering
 
@@ -86,7 +88,26 @@ i.e. `Filter` is applied to the objects before passing them to the `process` met
 
 ## Filtering and partitioning together
 
-Of course it should be possible to filter and partition data in the same task. The way this works is that multiple `Filter`s are logically ANDed together and then they will get anded with the OR of all the `Select` specified selections.
+It is also possible to filter and partition data in the same task. Therefore, multiple `Filter`s are combined using the logical `AND`. These filters then are combined by a logical `AND` with all the specified selections `Select`, which themself are combined by logical `OR`s. E.g. (Filter1 && Filter2) && (Select1 || Select2).
+
+```cpp
+using namespace o2::aod;
+
+using MyCompleteTracks = soa::Join<Tracks, TracksExtra, TracksDCA>;
+
+struct partandfiltexample {
+  Partition<Tracks> leftTracks = track::eta < 0;
+  Partition<Tracks> rightTracks = track::eta >= 0;
+  Filter etaFilter = nabs(track::eta) < 0.5f;
+  Filter trackQuality = track::tpcNClsFindable - track::tpcNClsFindableMinusCrossedRows >= 70;
+  Filter trackDCA = nabs(track::dcaXY) <= .2;
+
+  void process(Collision const& collision, soa::Filtered<MyCompleteTracks> const& tracks)
+  {
+    ...
+  }
+};
+```
 
 ## Configuring filters
 

--- a/docs/basics-tasks/IntroductionTables.md
+++ b/docs/basics-tasks/IntroductionTables.md
@@ -26,7 +26,7 @@ Be aware that tables can be [joined](../framework/framework.md#processing-relate
 ```
 
 In order to process the data, analysis task objects have to be written and have to subscribe to tables - i.e., they
-have to tell the framework that a certain table is of interest and will be processed by the task.
-In what folows, we will explain the basics regarding analysis tasks and the subscription to data.
+have to tell the framework that a certain table is of interest and will be processed by the task. 
+In what follows, we will explain the basics regarding analysis tasks and the subscription to data. 
 If you are interested in a reference guide that covers all the basic content of the tables that
 are currently in O2Physics, please refer to the automatically generated [Appendix: Data model reference](../09-appendix-fulldatatables/).

--- a/docs/basics-tasks/IntroductionTables.md
+++ b/docs/basics-tasks/IntroductionTables.md
@@ -22,11 +22,11 @@ For **each** index in a table, there is a method to get the corresponding object
 ```
 
 ```note
-Be aware that tables can be [joined](../framework/framework.md#processing-related-tables) and be [extended](../framework/framework.md#expression-columns) with extra colums.
+Be aware that tables can be [joined](../basics-task/SubscribingToData.md#processing-related-tables) and be [extended](../tutorials/extendedTables.md) with extra colums.
 ```
 
 In order to process the data, analysis task objects have to be written and have to subscribe to tables - i.e., they
-have to tell the framework that a certain table is of interest and will be processed by the task. 
-In what follows, we will explain the basics regarding analysis tasks and the subscription to data. 
+have to tell the framework that a certain table is of interest and will be processed by the task.
+In what follows, we will explain the basics regarding analysis tasks and the subscription to data.
 If you are interested in a reference guide that covers all the basic content of the tables that
-are currently in O2Physics, please refer to the automatically generated [Appendix: Data model reference](../09-appendix-fulldatatables/).
+are currently in O2Physics, please refer to the automatically generated [Appendix: Data model reference](../datamodel/README.md).

--- a/docs/basics-tasks/SubscribingToData.md
+++ b/docs/basics-tasks/SubscribingToData.md
@@ -77,7 +77,7 @@ This means that each subsequent argument is associated to all the one preceding 
 
 ## Processing related tables
 
-For performance reasons, sometimes it's a good idea to split data in separate tables, so that once can request only the subset which is required for a given task. For example, so far the track related information is split in three tables: `Tracks`, `TracksCov`, `TracksExtra`.
+For performance reasons, sometimes it's a good idea to split data in separate tables, so that one can request only the subset which is required for a given task. For example, so far the track related information is split in three tables: `Tracks`, `TracksCov`, `TracksExtra`.
 
 However you might need to get all the information at once. This can be done by asking for a `Join` table in the process method:
 

--- a/docs/basics-usage/JsonConfigs.md
+++ b/docs/basics-usage/JsonConfigs.md
@@ -77,4 +77,6 @@ For example the above json file is well adapted for the task `o2-analysis-mm-dnd
 
 `o2-analysis-timestamp --configuration json://config-file.json | o2-analysis-event-selection --configuration json://config-file.json | o2-analysis-trackextension --configuration json://config-file.json | o2-analysis-mm-dndeta --configuration json://config-file.json`
 
-*N.B. : You should provide the json file to each workflow separated by a pipe.*
+```note
+You should provide the json file to each workflow separated by a pipe.
+```

--- a/docs/basics-usage/ReadingTablesFromFile.md
+++ b/docs/basics-usage/ReadingTablesFromFile.md
@@ -10,7 +10,7 @@ The internal-dpl-aod-reader reads trees from root files and provides them as arr
 * --aod-file
 * --aod-reader-json
 
-### --aod-file
+### &#8208;&#8208;aod-file
 
 aod-file takes a string as option value, which either is the name of the input root file or, if starting with an `@`-character, is an ASCII-file which contains a list of input files.
 
@@ -23,7 +23,7 @@ aod-file takes a string as option value, which either is the name of the input r
 
 ```
 
-#### --aod-reader-json
+#### &#8208;&#8208;aod-reader-json
 
 aod-reader-json is a string and specifies a json file, which contains the
 customization information for the internal-dpl-aod-reader. An example file is

--- a/docs/basics-usage/SettingUp.md
+++ b/docs/basics-usage/SettingUp.md
@@ -26,7 +26,7 @@ A simple example is the histogram tutorial which you can run (on Run 2 converted
 o2-analysistutorial-histograms --aod-file AO2D.root
 ```
 
-In case you try the same on Run 3 data or MC, you also need the [track propagation task](../helperTasks/trackPropagation.md):
+In case you try the same on Run 3 data or MC, you also need the [track propagation task](https://aliceo2group.github.io/analysis-framework/docs/basics-usage/HelperTasks.html?highlight=track%20propagation#track-propagation):
 
 ```
 o2-analysis-timestamp | o2-analysis-track-propagation | o2-analysistutorial-histograms --aod-file AO2D.root

--- a/docs/basics-usage/SettingUp.md
+++ b/docs/basics-usage/SettingUp.md
@@ -22,19 +22,19 @@ workflow.
 
 A simple example is the histogram tutorial which you can run (on Run 2 converted data) with:
 
-```
+```bash
 o2-analysistutorial-histograms --aod-file AO2D.root
 ```
 
-In case you try the same on Run 3 data or MC, you also need the [track propagation task](https://aliceo2group.github.io/analysis-framework/docs/basics-usage/HelperTasks.html?highlight=track%20propagation#track-propagation):
+In case you try the same on Run 3 data or MC, you also need the [track propagation task](HelperTasks.md#track-propagation):
 
-```
+```bash
 o2-analysis-timestamp | o2-analysis-track-propagation | o2-analysistutorial-histograms --aod-file AO2D.root
 ```
 
 Single task executables are combined with the pipe ( &#124; ) operator, e.g.
 
-```
+```bash
 o2-analysis-timestamp | o2-analysis-event-selection | o2-analysis-trackextension
 | o2-analysis-trackselection | o2-analysis-ud-mytask --aod-file AO2D.root
 ```

--- a/docs/troubleshooting/README.md
+++ b/docs/troubleshooting/README.md
@@ -39,9 +39,8 @@ o2-analysis-timestamp | o2-analysis-my-analysis ...
 
 and the table should be found.
 
-If you run on Run 3 data or MC and the missing table is "O2tracks", please refer to the documentation on the [track propagation](https://aliceo2group.github.io/analysis-framework/docs/basics-usage/HelperTasks.html?highlight=track%20propagation#track-propagation).
+If you run on Run 3 data or MC and the missing table is "O2tracks", please refer to the documentation on the [track propagation](../basics-usage/HelperTasks.md#track-propagation).
 
+If you are running on Run 3 data or MC and the missing table is "O2fv0c", please make sure that the process switches in the bc-selection, event-selection and multiplicity-table workflows are set to `"processRun2": "false", "processRun3": "true"` in your config JSON; see e.g. the "Configurables" section in the [event selection](../basics-usage/HelperTasks.md#event-selection) documentation.
 
-If you are running on Run 3 data or MC and the missing table is "O2fv0c", please make sure that the process switches in the bc-selection, event-selection and multiplicity-table workflows are set to `"processRun2": "false", "processRun3": "true"` in your config JSON; see e.g. the "Configurables" section in the [event selection](../helperTasks/eventselection.md#configurables) documentation.
-
-If the misssing table is `O2tofsignal`, please refer to the documentation on the [TOF PID](../helperTasks/pid.md) requirements.
+If the misssing table is `O2tofsignal`, please refer to the documentation on the [TOF PID](../basics-usage/HelperTasks.md#particle-identification) requirements.

--- a/docs/troubleshooting/README.md
+++ b/docs/troubleshooting/README.md
@@ -39,7 +39,8 @@ o2-analysis-timestamp | o2-analysis-my-analysis ...
 
 and the table should be found.
 
-If you run on Run 3 data or MC and the missing table is "O2tracks", please refer to the documentation on the [track propagation](../helperTasks/trackPropagation.md).
+If you run on Run 3 data or MC and the missing table is "O2tracks", please refer to the documentation on the [track propagation](https://aliceo2group.github.io/analysis-framework/docs/basics-usage/HelperTasks.html?highlight=track%20propagation#track-propagation).
+
 
 If you are running on Run 3 data or MC and the missing table is "O2fv0c", please make sure that the process switches in the bc-selection, event-selection and multiplicity-table workflows are set to `"processRun2": "false", "processRun3": "true"` in your config JSON; see e.g. the "Configurables" section in the [event selection](../helperTasks/eventselection.md#configurables) documentation.
 

--- a/docs/tutorials/analysistask.md
+++ b/docs/tutorials/analysistask.md
@@ -11,7 +11,7 @@ This explains the basic blocks and structures an analysis task in O2 is built of
 
 ## License agreement
 
-At the very beginning of each analysis task code file we recommend to but the following license agreement. The task will also run without, but with these lines you confirm that your program is
+At the very beginning of each analysis task code file we recommend to put the following license agreement. The task will also run without, but with these lines you confirm that your program is
 <a href="https://www.gnu.org/philosophy/free-sw.html" target="_blank">free software</a>. You can find the full O2 license information <a href="https://alice-o2-project.web.cern.ch/license" target="_blank">here</a>.
 
 `License agreement`
@@ -58,7 +58,7 @@ All tables of the ALICE O2 analysis data model reside in the namespace o2::aod. 
 
 ## Tasks, workflows, data analysis
 
-A task is a basic block of an analysis program. It it a struct and has an init and a process function. In order to be complete either of the two functions must be defined.
+A task is a basic block of an analysis program. It is a struct and has an init and a process function. In order to be complete either of the two functions must be defined.
 
 Several tasks can be put together to form a workflow (using defineDataProcessing()). Workflows on the other hand can be chained - the output of one workflow is piped to the input of the other workflow.
 

--- a/docs/tutorials/analysistask.md
+++ b/docs/tutorials/analysistask.md
@@ -62,7 +62,7 @@ A task is a basic block of an analysis program. It is a struct and has an init a
 
 Several tasks can be put together to form a workflow (using defineDataProcessing()). Workflows on the other hand can be chained - the output of one workflow is piped to the input of the other workflow.
 
-This is discussed in more detail in the [Data Processing](../framework/framework.md) section of these documentation pages.
+This is discussed in more detail in the [Data Processing](../basics-usage/SettingUp.md) section of these documentation pages.
 
 So this is kind of a workflow skeleton
 

--- a/docs/tutorials/extendedTables.md
+++ b/docs/tutorials/extendedTables.md
@@ -16,7 +16,7 @@ Learn how add new columns to existing tables, use dynamic and expression columns
 
 <a name="extendtable"></a>
 
-### ExtendTable
+## ExtendTable
 
 Existing tables can be extended with additional expression columns using the 'Extend" function. The first step is the declaration of the new expression column (see also tutorial [Creating Tables](creatingTables.md)).
 
@@ -48,7 +48,7 @@ Note that the argument of the Extend function (here track) is a table object and
 
 <a name="attachcolumn"></a>
 
-### AttachColumn
+## AttachColumn
 
 Extend can only be used with expression columns. The function to extend a table with a dynamic column is `Attach`.
 
@@ -76,13 +76,13 @@ struct AttachColumn {
 
 <a name="extendandattach"></a>
 
-### ExtendAndAttach
+## ExtendAndAttach
 
 The two types of extension can be combined as demonstrated in task ExtendAndAttach.
 
 <a name="spawndynamiccolumns"></a>
 
-### SpawnDynamicColumns and ProcessExtendedTables
+## SpawnDynamicColumns and ProcessExtendedTables
 
 A Similar effect can be achieved by joining tables with the soa::Join helper function. Again we need some declarations at the beginning.
 

--- a/docs/tutorials/extendedTables.md
+++ b/docs/tutorials/extendedTables.md
@@ -18,7 +18,7 @@ Learn how add new columns to existing tables, use dynamic and expression columns
 
 ### ExtendTable
 
-Existing tables can be extended with additional expression columns using the 'Extend" function. The first step is the declaration of the new expression column (see also tutorial [Creating Tables](creatingTables)).
+Existing tables can be extended with additional expression columns using the 'Extend" function. The first step is the declaration of the new expression column (see also tutorial [Creating Tables](creatingTables.md)).
 
 ```cpp
 # declare expression column P2

--- a/docs/tutorials/extendedTables.md
+++ b/docs/tutorials/extendedTables.md
@@ -71,7 +71,7 @@ and in this example add it with the Attach function to the table Tracks.
 struct AttachColumn {
   void process(aod::Collision const&, aod::Tracks const& tracks)
   {
-    auto table_extension = soa::Attach<aod::Tracks, aod::extension::R2dyn<aod::track::X,aod::track::Y> (tracks);
+    auto table_extension = soa::Attach<aod::Tracks, aod::extension::R2dyn<aod::track::X,aod::track::Y>> (tracks);
 ```
 
 <a name="extendandattach"></a>


### PR DESCRIPTION
- Fixed some typos within the documentation.
- Added some examples and replaced ToDo's.
- Fixed linking errors.
