### PR TITLE
Add a Support section and change order of the "Getting started" sections

### DIFF
--- a/docs/gettingstarted/contributingtocode.md
+++ b/docs/gettingstarted/contributingtocode.md
@@ -1,5 +1,5 @@
 ---
-sort: 4
+sort: 5
 title: Contributing to the repository
 ---
 # Contributing to the repository

--- a/docs/gettingstarted/contributingtodocs.md
+++ b/docs/gettingstarted/contributingtodocs.md
@@ -1,5 +1,5 @@
 ---
-sort: 5
+sort: 6
 title: Editing this documentation
 ---
 

--- a/docs/gettingstarted/gitbasics.md
+++ b/docs/gettingstarted/gitbasics.md
@@ -1,5 +1,5 @@
 ---
-sort: 1
+sort: 4
 title: Git basics
 ---
 

--- a/docs/gettingstarted/support.md
+++ b/docs/gettingstarted/support.md
@@ -1,0 +1,16 @@
+---
+sort: 8
+title: Support
+---
+
+# Support
+
+## Support venues
+
+The primary venue for support is Mattermost. Please login to [Mattermost](https://mattermost.web.cern.ch) and join the restricted team ALICE (top menu, select join restricted teams). You should then join the following support channels on Mattermost:
+
+- [O2 Analysis](https://mattermost.web.cern.ch/alice/channels/o2-analysis): meant for general support. Please feel free to write here!
+- [O2 Analysis Announcements](https://mattermost.web.cern.ch/alice/channels/o2-analysis-announcements): meant for announcements that impact everyone.
+- [O2 Hyperloop Operation](https://mattermost.web.cern.ch/alice/channels/o2-hyperloop-operation): meant to bookkeep Hyperloop operational information and train requests.
+
+A legacy support venue is the alice project analysis task force mailing list: [alice-project-analysis-task-force@cern.ch](mailto:alice-project-analysis-task-force@cern.ch).

--- a/docs/gettingstarted/support.md
+++ b/docs/gettingstarted/support.md
@@ -1,5 +1,5 @@
 ---
-sort: 8
+sort: 1
 title: Support
 ---
 
@@ -7,10 +7,11 @@ title: Support
 
 ## Support venues
 
-The primary venue for support is Mattermost. Please login to [Mattermost](https://mattermost.web.cern.ch) and join the restricted team ALICE (top menu, select join restricted teams). You should then join the following support channels on Mattermost:
+The primary venue for support is Mattermost. Please login to [Mattermost](https://mattermost.web.cern.ch) and join the restricted team ALICE (top menu, select join restricted teams).
+You should then join the following support channels on Mattermost:
 
-- [O2 Analysis](https://mattermost.web.cern.ch/alice/channels/o2-analysis): meant for general support. Please feel free to write here!
-- [O2 Analysis Announcements](https://mattermost.web.cern.ch/alice/channels/o2-analysis-announcements): meant for announcements that impact everyone.
-- [O2 Hyperloop Operation](https://mattermost.web.cern.ch/alice/channels/o2-hyperloop-operation): meant to bookkeep Hyperloop operational information and train requests.
+- [O2 Analysis](https://mattermost.web.cern.ch/alice/channels/o2-analysis) - meant for general support. Please feel free to write here!
+- [O2 Analysis Announcements](https://mattermost.web.cern.ch/alice/channels/o2-analysis-announcements) - meant for announcements that impact everyone.
+- [O2 Hyperloop Operation](https://mattermost.web.cern.ch/alice/channels/o2-hyperloop-operation) - meant to bookkeep Hyperloop operational information and train requests.
 
 A legacy support venue is the alice project analysis task force mailing list: [alice-project-analysis-task-force@cern.ch](mailto:alice-project-analysis-task-force@cern.ch).

--- a/docs/troubleshooting/README.md
+++ b/docs/troubleshooting/README.md
@@ -1,19 +1,9 @@
 ---
 sort: 8
-title: Support and troubleshooting
+title: Troubleshooting
 ---
 
-# Support and troubleshooting
-
-## Support venues
-
-The primary venue for support is Mattermost. Please login to [Mattermost](https://mattermost.web.cern.ch) and join the restricted team ALICE (top menu, select join restricted teams). You should then join the following support channels on Mattermost:
-
-- [O2 Analysis](https://mattermost.web.cern.ch/alice/channels/o2-analysis): meant for general support. Please feel free to write here!
-- [O2 Analysis Announcements](https://mattermost.web.cern.ch/alice/channels/o2-analysis-announcements): meant for announcements that impact everyone.
-- [O2 Hyperloop Operation](https://mattermost.web.cern.ch/alice/channels/o2-hyperloop-operation): meant to bookkeep hyperloop operational information and train requests.
-
-A legacy support venue is the alice project analysis task force mailing list: <a href="mailto:alice-project-analysis-task-force@cern.ch">alice-project-analysis-task-force@cern.ch</a>.
+# Troubleshooting
 
 ## Typical problems and solutions
 


### PR DESCRIPTION
- I split the "Support and troubleshooting" section and moved the support part up as the very first section in the "Getting started" block, because I think this is the most important information that every newcomer should see first and should be the easiest to find.
- I also changed the order of the sections in the "Getting started" block to better correspond to the chronological order of the steps that a new contributor/analyser usually takes:
  - Support
  - Installing O2 and O2Physics
  - The O2Physics repository structure
  - Git basics
  - Contributing to the repository
  - Editing this documentation
