### PR TITLE
Update "isMC" Configurable in HelperTasks.md

### DIFF
--- a/docs/basics-usage/HelperTasks.md
+++ b/docs/basics-usage/HelperTasks.md
@@ -341,7 +341,7 @@ Event selection task supports several configurables:
 * _isMC_ allows to suppress several checks for Run 2 MC, see [Event selection decisions](#event-selection-decisions):
 
   ``` c++
-  Configurable<bool> isMC{"isMC", 0, "0 - data, 1 - MC"};
+  Configurable<int> isMC{"isMC", 0, "-1 - autoset, 0 - data, 1 - MC"};
   ```
 
   Note that one has to enable _isRun2MC_ flag in the timestamp task in this case:


### PR DESCRIPTION
Since [this PR](https://github.com/AliceO2Group/O2Physics/pull/6807), `isMC` is no longer a `bool` but instead an `int`. Since this breaks things like `"isMC" : "false"` in the json configuration, I've updated the doc to reflect this change!

