### PR TITLE
Update example json config file

### DIFF
--- a/docs/basics-usage/JsonConfigs.md
+++ b/docs/basics-usage/JsonConfigs.md
@@ -43,7 +43,7 @@ that one wishes to execute.
         "syst": "pp",
         "muonSelection": "0",
         "customDeltaBC": "300",
-        "isMC": "true",
+        "isMC": "1",
         "processRun2": "false",
         "processRun3": "true"
     },
@@ -67,7 +67,7 @@ that one wishes to execute.
 
 In the above example of json file, in the `pseudorapidity-density` section (line 37 to 44), you can see the different values of the configurables, `maxDCAZ` is now 3.2 for instance. You can also specify the type of data you are processing with the flags `processRun2` `processRun3` and `isMC`.
 
-Another very useful thing is that inside this file you can provide a list of aod files to analyse, as you can see the line 10 `"aod-file": "@inputs-sim.txt"` means that the workflow will analyse the all the files contained in the txt file `inputs-sim.txt`, with one file name per line.
+Another very useful thing is that inside this file you can provide a list of aod files to analyse, as you can see the line 10 `"aod-file-private": "@inputs-sim.txt"` means that the workflow will analyse the all the files contained in the txt file `inputs-sim.txt`, with one file name per line.
 
 ## How to give this json file to the workflow
 


### PR DESCRIPTION
Updated the example json config file to reflect the `bool` to `int` change for `isMC`. Also updated the explanation text to update `aod-file` to `aod-file-private`.

