### PR TITLE
Remove the instruction to start a PR title with the PWG name

### DIFF
--- a/docs/advanced-specifics/pwghf.md
+++ b/docs/advanced-specifics/pwghf.md
@@ -279,7 +279,5 @@ Example:
 
 - Update your branch and test it before creating a PR.
 - Give your PR a short meaningful title.
-  - Add the “PWGHF: ” prefix in the title of your PR. (It helps to search for PWGHF-related PRs in the commit history of the main branch.)
-    - Note: If your PR has only one commit, add the prefix also in the commit title (because that is the title that will appear in the history after merging, unless the person merging the PR changes it by hand).
 - Give further useful details about your changes in the PR description.
   - Add links to all related PRs (e.g. O2Physics, O2, AliPhysics, Run3Analysisvalidation) in the PR description.

--- a/docs/gettingstarted/contributingtocode.md
+++ b/docs/gettingstarted/contributingtocode.md
@@ -62,7 +62,6 @@ __Give your pull request a short and meaningful title.__
 
 - The title should be informative enough to give an idea of _what_ was changed and _where_.
 - Further details (e.g. _why_ this change is needed or related links) can be provided in the description below the title.
-- It is useful to put the PWG name at the beginning of the PR title to specify the scope of the changes, which makes it easier to filter PRs related to the PWG in the PR history and also in the commit history of the main branch.
 - Examples of too vague titles: "Test", "Fix bug", "Add new parameter", "Update cuts", "Improve code".
 
 ### Automatic checks


### PR DESCRIPTION
Since https://github.com/AliceO2Group/O2Physics/pull/8086 a prefix with the PWG name is automatically added or checked.

