### PR TITLE
Add protection against missing lsb_release in the setup summary script

### DIFF
--- a/docs/troubleshooting/summarise_o2p_setup.sh
+++ b/docs/troubleshooting/summarise_o2p_setup.sh
@@ -4,10 +4,10 @@
 
 # System info
 
-systemName=""
-user=""
+systemName="Failed to get"
+user="Failed to get"
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-  systemName="$(lsb_release -ds)"
+  [[ -n "$(which lsb_release)" ]] && systemName="$(lsb_release -ds)"
   user="$(whoami)"
 elif [[ "$OSTYPE" == "darwin"* ]]; then
   systemName="$(sw_vers -productName) $(sw_vers -productVersion)"


### PR DESCRIPTION
Apparently, `lsb_release` is not installed on Alma by default.