### PR TITLE
Fix gem dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,5 @@ source "https://rubygems.org" # source "https://gems.ruby-china.com"
 gemspec
 
 gem "github-pages", group: :jekyll_plugins
+
+gem "webrick", "~> 1.9"

--- a/jekyll-rtd-theme.gemspec
+++ b/jekyll-rtd-theme.gemspec
@@ -10,5 +10,5 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r!^(assets|_layouts|_includes|_sass|LICENSE|README)!i) }
 
-  spec.add_runtime_dependency "github-pages", "~> 209"
+  spec.add_runtime_dependency "github-pages", "~> 232"
 end


### PR DESCRIPTION
Executing `bundle exec jekyll serve` fails with:

```
  Liquid Exception: undefined method `tainted?' for nil:NilClass in assets/404.liquid
jekyll 3.9.0 | Error:  undefined method `tainted?' for nil:NilClass
```

This PR fixes it.